### PR TITLE
feat: add page routing, SpecPage, and canvas error handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import ApiNode from './ApiNode';
 import { irToFlow } from './irToFlow';
 import PromptDialog from './components/PromptDialog';
 import Sidebar from './components/Sidebar';
+import SpecPage from './pages/SpecPage';
 import { usePromptChat } from './hooks/usePromptChat';
 
 const nodeTypes = { table: TableNode, api: ApiNode };
@@ -27,19 +28,31 @@ const apiFill = (m = '') => {
 };
 
 export default function App() {
+  const [page, setPage] = useState('canvas');
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const [loadError, setLoadError] = useState(null);
   const rfRef = useRef(null);
 
   const loadIR = async () => {
-    const ir = await fetch(`${API_BASE}/ir`).then(r => r.json());
+    setLoadError(null);
+    const res = await fetch(`${API_BASE}/ir`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const ir = await res.json();
     const { nodes, edges } = irToFlow(ir);
     setNodes(nodes);
     setEdges(edges);
     setTimeout(() => rfRef.current?.fitView({ padding: 0.2 }), 0);
   };
 
-  useEffect(() => { loadIR().catch(console.error); }, []);
+  useEffect(() => {
+    if (page === 'canvas') {
+      loadIR().catch((err) => {
+        console.error('[loadIR]', err);
+        setLoadError(`無法載入資料：${err.message}`);
+      });
+    }
+  }, [page]);
 
   // ✅ 把對話窗邏輯全交給 Hook
   const chat = usePromptChat({
@@ -49,52 +62,65 @@ export default function App() {
 
   return (
     <div className="sg-app">
-      <Sidebar onSelect={(key)=>console.log('sidebar select:', key)} />
+      <Sidebar activePage={page} onSelect={setPage} />
       <main className="sg-main">
-        <div style={{ width: '100vw', height: '100vh' }}>
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        nodeTypes={nodeTypes}
-        fitView
-        onInit={(inst) => (rfRef.current = inst)}
-      >
-        <Background variant="dots" gap={16} size={1} />
-        <Controls showInteractive />
-        <MiniMap
-          zoomable
-          pannable
-          nodeColor={(n) => (n.type === 'api' ? apiFill(n.data?.method) : '#bfdbfe')}
-          nodeStrokeWidth={2}
-          style={{ width: 180, height: 120, left: 16, bottom: 16, right: 'auto', top: 'auto' }}
-        />
-      </ReactFlow>
+        {page === 'specs' ? (
+          <SpecPage />
+        ) : (
+          <div style={{ width: '100%', height: '100vh' }}>
+            {loadError && (
+              <div style={{
+                position: 'absolute', top: 16, left: '50%', transform: 'translateX(-50%)',
+                background: '#fef2f2', border: '1px solid #fca5a5', color: '#991b1b',
+                borderRadius: 8, padding: '8px 16px', zIndex: 10,
+              }}>
+                {loadError}
+              </div>
+            )}
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              nodeTypes={nodeTypes}
+              fitView
+              onInit={(inst) => (rfRef.current = inst)}
+            >
+              <Background variant="dots" gap={16} size={1} />
+              <Controls showInteractive />
+              <MiniMap
+                zoomable
+                pannable
+                nodeColor={(n) => (n.type === 'api' ? apiFill(n.data?.method) : '#bfdbfe')}
+                nodeStrokeWidth={2}
+                style={{ width: 180, height: 120, left: 16, bottom: 16, right: 'auto', top: 'auto' }}
+              />
+            </ReactFlow>
 
-      {/* ✅ 展示型元件，從 Hook 拿 props */}
-      <PromptDialog {...chat.dialogProps} />
+            {/* ✅ 展示型元件，從 Hook 拿 props */}
+            <PromptDialog {...chat.dialogProps} />
 
-      {/* 固定在視窗右下角，不受 canvas 水平位置影響 */}
-      <button
-        onClick={chat.openDialog}
-        style={{
-          position: 'fixed',
-          bottom: 16,
-          right: 16,
-          width: 120,
-          height: 36,
-          borderRadius: 8,
-          border: '1px solid #e5e7eb',
-          background: '#111827',
-          color: '#fff',
-          cursor: 'pointer',
-          zIndex: 1000,
-        }}
-      >
-        💬 Prompt
-      </button>
-    </div>
+            {/* 固定在視窗右下角，不受 canvas 水平位置影響 */}
+            <button
+              onClick={chat.openDialog}
+              style={{
+                position: 'fixed',
+                bottom: 16,
+                right: 16,
+                width: 120,
+                height: 36,
+                borderRadius: 8,
+                border: '1px solid #e5e7eb',
+                background: '#111827',
+                color: '#fff',
+                cursor: 'pointer',
+                zIndex: 1000,
+              }}
+            >
+              💬 Prompt
+            </button>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 const defaultItems = [
+  { key: 'canvas', label: '🗺️ Canvas' },
   { key: 'specs', label: '📄 Specs' },
   { key: 'apis', label: '🔌 APIs' },
   { key: 'tables', label: '🗄️ Tables' },
@@ -8,7 +9,7 @@ const defaultItems = [
   { key: 'rag', label: '🧠 RAG' },
 ];
 
-export default function Sidebar({ items = defaultItems, onSelect }) {
+export default function Sidebar({ items = defaultItems, activePage, onSelect }) {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
@@ -30,7 +31,7 @@ export default function Sidebar({ items = defaultItems, onSelect }) {
         {items.map((it) => (
           <button
             key={it.key}
-            className="sg-nav__item"
+            className={`sg-nav__item${activePage === it.key ? ' active' : ''}`}
             onClick={() => onSelect?.(it.key)}
             title={it.label}
           >

--- a/src/index.css
+++ b/src/index.css
@@ -24,9 +24,12 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
+  min-height: 100vh;
+}
+
+#root {
+  width: 100%;
   min-height: 100vh;
 }
 
@@ -68,7 +71,7 @@ button:focus-visible {
 }
 
 /* ===== SpecGenie App Shell ===== */
-.sg-app { display: flex; min-height: 100vh; }
+.sg-app { display: flex; width: 100%; min-height: 100vh; }
 .sg-main { flex: 1; position: relative; padding: 12px; }
 
 .sg-sidebar {
@@ -101,6 +104,7 @@ button:focus-visible {
   border-radius: 10px; padding: 10px 12px; cursor: pointer; text-align: left;
 }
 .sg-nav__item:hover { background: #1f2937; border-color: #374151; }
+.sg-nav__item.active { background: #1f2937; border-color: #4b5563; color: #fff; }
 
 .sg-nav__icon { width: 20px; display: inline-flex; justify-content: center; }
 .sg-sidebar.collapsed .sg-nav__text { display: none; }

--- a/src/pages/SpecPage.jsx
+++ b/src/pages/SpecPage.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+export default function SpecPage() {
+  const [content, setContent] = useState('');
+
+  return (
+    <div style={{
+      width: '100%',
+      height: 'calc(100vh - 24px)',
+      background: '#fff',
+      borderRadius: 12,
+      overflowY: 'auto',
+    }}>
+      <div style={{
+        maxWidth: 720,
+        margin: '0 auto',
+        padding: '60px 24px',
+      }}>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="在這裡撰寫系統規格..."
+          style={{
+            width: '100%',
+            minHeight: 'calc(100vh - 180px)',
+            background: 'transparent',
+            color: '#37352f',
+            border: 'none',
+            outline: 'none',
+            resize: 'none',
+            fontSize: 16,
+            lineHeight: 1.8,
+            fontFamily: 'inherit',
+          }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add page state to App for sidebar navigation (canvas / specs)
- Add SpecPage placeholder with Notion-style textarea
- Add Sidebar activePage prop with active highlight
- Fix body CSS: remove Vite boilerplate display:flex/place-items:center
- Add #root sizing to fix ReactFlow black canvas issue
- Fix canvas container: 100vw → 100% to prevent horizontal overflow
- Add res.ok check and loadError state with error banner in canvas
- Remove duplicate useEffect that called loadIR twice on mount